### PR TITLE
add submodule update to setup in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ The following three steps to connect to Amazon Keyspaces using the Toolkit. Clon
 
 ```sh
   git clone https://github.com/aws-samples/amazon-keyspaces-toolkit .
+  git submodule update --init --recursive
 
   docker build --tag amazon/keyspaces-toolkit .
 


### PR DESCRIPTION
*Issue #, if available:*
#1 

*Description of changes:*
This project pulls a submodule for cassandra but steps in the README don't specify to update/init that submodule so the `docker build` command fails since `cassandra/` is empty.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
