### PR TITLE
Changes cert from  AmazonRootCA1.pem to sf-class2-root.crt

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ COPY cassandra/lib/*.zip $CASSANDRA_HOME/lib/
 COPY bin/ $AWS_KEYSPACES_WORKING_DIR/bin/
 
 #Setup pem file
-ADD https://www.amazontrust.com/repository/AmazonRootCA1.pem $CQLSHRC_HOME/AmazonRootCA1.pem
+ADD https://certs.secureserver.net/repository/sf-class2-root.crt $CQLSHRC_HOME/sf-class2-root.crt
 COPY cqlshrc $CQLSHRC_HOME/cqlshrc
 
 ENV PATH="${PATH}:$AWS_KEYSPACES_WORKING_DIR/bin:$CASSANDRA_HOME/bin"

--- a/cqlshrc
+++ b/cqlshrc
@@ -4,7 +4,7 @@ factory = cqlshlib.ssl.ssl_transport_factory
 
 [ssl]
 validate = true
-certfile =  /root/.cassandra/AmazonRootCA1.pem
+certfile =  /root/.cassandra/sf-class2-root.crt
 
 [copy]
 NUMPROCESSES=16


### PR DESCRIPTION
Changed cert to the latest one that we have been issued. 

Useful as the cqlshrc is now referenced in documentation

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
