### PR TITLE
Specifies the SSL Version to be TLSv1_2

### DIFF
--- a/cqlshrc
+++ b/cqlshrc
@@ -5,6 +5,7 @@ factory = cqlshlib.ssl.ssl_transport_factory
 [ssl]
 validate = true
 certfile =  /root/.cassandra/sf-class2-root.crt
+version = TLSv1_2
 
 [copy]
 NUMPROCESSES=16


### PR DESCRIPTION
FIPS endpoints requires explicit specification of SSL version.
As this will also work for other endpoints, we specify this so
that the documentation can mention only a single source of truth.

Ran through test script and manual verification

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
