### PR TITLE
plain text auth provider fix

### DIFF
--- a/cqlsh-expansion/bin/cqlsh-expansion.py
+++ b/cqlsh-expansion/bin/cqlsh-expansion.py
@@ -480,14 +480,17 @@ class Shell(cmd.Cmd):
           if options.auth_provider_name == 'SigV4AuthProvider':
             my_session = boto3.session.Session()
             self.auth_provider = SigV4AuthProvider(my_session)
-          elif auth_provider_name == DEFAULT_AUTH_PROVIDER:
+          elif options.auth_provider_name == DEFAULT_AUTH_PROVIDER:
             if username:
                if not password:
                    password = getpass.getpass()
                self.auth_provider = PlainTextAuthProvider(username=username, password=password)
             else:
               raise SyntaxError('cqlsh-expansion.py Invalid parameter for auth-provider. "%s" is not a valid AuthProvider' % (auth_provider,))
-
+        elif username:
+            if not password:
+                password = getpass.getpass()
+            self.auth_provider = PlainTextAuthProvider(username=username, password=password)
 
         self.username = username
         self.keyspace = keyspace


### PR DESCRIPTION
*Issue #, if available:* with cqlsh-expansion the PlainTextAuthentication fails and also currently we are forcing user to give auth-provider if they are using username and password

*Description of changes:*
1.) For cqlsh-expansion  to work with the PlainTextAuthentication when auth provider is given changed auth_provider_name to options.auth_provider_name 
2.) If user is using username and password they don't need to provider auth provider 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
