### PR TITLE
PlainTextAuth with username and password 

### DIFF
--- a/cqlsh-expansion/bin/cqlsh-expansion.py
+++ b/cqlsh-expansion/bin/cqlsh-expansion.py
@@ -480,14 +480,17 @@ class Shell(cmd.Cmd):
           if options.auth_provider_name == 'SigV4AuthProvider':
             my_session = boto3.session.Session()
             self.auth_provider = SigV4AuthProvider(my_session)
-          elif auth_provider_name == DEFAULT_AUTH_PROVIDER:
+          elif options.auth_provider_name == DEFAULT_AUTH_PROVIDER:
             if username:
                if not password:
                    password = getpass.getpass()
                self.auth_provider = PlainTextAuthProvider(username=username, password=password)
             else:
               raise SyntaxError('cqlsh-expansion.py Invalid parameter for auth-provider. "%s" is not a valid AuthProvider' % (auth_provider,))
-
+        elif username:
+            if not password:
+                password = getpass.getpass()
+            self.auth_provider = PlainTextAuthProvider(username=username, password=password)
 
         self.username = username
         self.keyspace = keyspace

--- a/cqlsh-expansion/bin/cqlsh-expansion.py
+++ b/cqlsh-expansion/bin/cqlsh-expansion.py
@@ -482,14 +482,15 @@ class Shell(cmd.Cmd):
             self.auth_provider = SigV4AuthProvider(my_session)
           elif options.auth_provider_name == DEFAULT_AUTH_PROVIDER:
             if username:
-               if not password:
-                   password = getpass.getpass()
-               self.auth_provider = PlainTextAuthProvider(username=username, password=password)
-            else:
-              raise SyntaxError('cqlsh-expansion.py Invalid parameter for auth-provider. "%s" is not a valid AuthProvider' % (auth_provider,))
-        elif username:
-            if not password:
+              if not password:
                 password = getpass.getpass()
+              self.auth_provider = PlainTextAuthProvider(username=username, password=password)
+          else:
+              raise SyntaxError('cqlsh-expansion.py Invalid parameter for auth-provider. "%s" is not a valid AuthProvider' % (auth_provider,))
+        else:
+          if username:
+            if not password:
+               password = getpass.getpass()
             self.auth_provider = PlainTextAuthProvider(username=username, password=password)
 
         self.username = username


### PR DESCRIPTION
*Issue #, if available:* authentication doesn't work without providing auth provider

*Description of changes:*
made code changes to if else block to work PlainTextAuth with username and password with or without flag

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
